### PR TITLE
RItools update

### DIFF
--- a/mass_prep.Rmd
+++ b/mass_prep.Rmd
@@ -8,7 +8,7 @@ output: pdf_document
 To begin, I read in my data from the CDC.
 
 ```{r}
-if (is.null(datadir)) #reproduce results from when below were hard-coded; see dot-Renviron-template.txt
+if (!exists('datadir') || is.null(datadir)) #reproduce results from when below were hard-coded; see dot-Renviron-template.txt
 {
 datadir = "~/Downloads/" 
 mortdatadir = "~/Downloads/mort/"

--- a/mass_prep.Rmd
+++ b/mass_prep.Rmd
@@ -22,8 +22,8 @@ pop99 = read.fwf(paste0(datadir, 'pop9913.txt'), width=c(2,3,4,1,1,rep(8,14),25,
 colnames(pop99) = c('state','county','year','racesex','hisp','birth','l1','a14','a59','a1014','a1519','a2024','a2534','a3544','a4554','a5564','a6574','a7584','a85','name','type')
 arf = read.csv(paste0(datadir, 'arfarfsixten.csv'), header=T)
 colnames(arf) = c('state','county','med610','medinc10','medinc06','pov10','pov06','ins10','ins06','unemp10','unemp06')
-arf08 = read.csv(paste0(datadir, 'arf08vars.csv'), header=T)
-arf12 = read.csv(paste0(datadir, 'arf12vars.csv'), header=T) 
+arf08 = read.csv(paste0('./', 'arf08vars.csv'), header=T)
+arf12 = read.csv(paste0('./', 'arf12vars.csv'), header=T) 
 colnames(arf08) = c('state','county','inc07','inc06','inc05','inc04','inc03','inc02',
                     'inc01','inc00',
                     'pov07','pov06','pov05','pov04','pov03','pov02','pov01','pov00',

--- a/massrep.Rmd
+++ b/massrep.Rmd
@@ -30,10 +30,10 @@ load(prepped_data_file)
 stopifnot(file.exists("./lib"))
 if ( file.exists(paste0("./lib/", R.version[['platform']], "-library") ) )
 {
-  with_libpaths(with(R.version, paste0("./lib/", platform, "-library/", major, ".", substr(minor, 1,1))),
+  withr::with_libpaths(with(R.version, paste0("./lib/", platform, "-library/", major, ".", substr(minor, 1,1))),
 		library(RItools)
 		)
-} else with_libpaths("lib/", library(RItools))
+} else withr::with_libpaths("lib/", library(RItools))
 
 library(reshape2)
 library(car)
@@ -120,11 +120,11 @@ men.control = subset(men.control, men.control$treat!=1)
 men.control = subset(men.control, men.control$fit>top4)
 men.study = rbind(men.treat, men.control)
 ##an unweighted balance assessment for 2005 
-xBalance(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+mr01
+balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+mr01
          +mr02+
            mr03+mr04+pov05+inc05+emp05+ins05, data=men.study, report=c('all'))
 ##weighted balance assessment for 2005
-xBalance(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+mr01
+balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+mr01
          +mr02+
            mr03+mr04+pov05+inc05+emp05+ins05, element.weights=pops, 
          data=men.study, report=c('all'))
@@ -144,11 +144,11 @@ men.control = subset(men.control, men.control$treat!=1)
 men.control = subset(men.control, men.control$fit>top4)
 men.study = rbind(men.treat, men.control)
 ##an unweighted balance assessment for 2006
-xBalance(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+
+balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+
            mr01+mr02+
            mr03+mr04+pov06+inc06+emp06+ins06, data=men.study, report=c('all'))
 ##weighted balance assessment for 2006
-xBalance(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+
+balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+
            mr01+mr02+
            mr03+mr04+pov06+inc06+emp06+ins06, element.weights=pops, 
          data=men.study, report=c('all'))
@@ -178,9 +178,9 @@ men.study.out$mr09d = men.study.out$mr09 - men.study.out$mr06
 men.study.out$mr10d = men.study.out$mr10 - men.study.out$mr06
 
 colnames(men.study.out)
-xBalance(treat~mr07+mr08+mr09+mr10, element.weights=pops, data=men.study.out,
+balanceTest(treat~mr07+mr08+mr09+mr10, element.weights=pops, data=men.study.out,
          report=c('z.scores', 'p.value', 'chisquare.test'))
-xBalance(treat~mr07d+mr08d+mr09d+mr10d, element.weights=pops, data=men.study.out,
+balanceTest(treat~mr07d+mr08d+mr09d+mr10d, element.weights=pops, data=men.study.out,
          report=c('z.scores', 'p.value', 'chisquare.test'))
 
 ##negative binomial model
@@ -235,10 +235,10 @@ model2=glm(treat~a2034+a3544+a4554+male+white+black+hisp+mr01+mr02+mr03+mr04+mr0
 fm2<-fullmatch(model2,data=model2data,omit.fraction=3/4)
 summary(fm2)
 stratumStructure(fm2)
-xBalance(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+
+balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+
            hisp+mr05+mr06+mr01+mr02+mr03+mr04+pov06+medinc06+unemp06+
            ins06+strata(fm2),data=model2data,report=c('z','chisquare.test'))
-xBalance(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+
+balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+
            hisp+mr05+mr06+mr01+mr02+mr03+mr04+pov06+medinc06+unemp06+
            ins06+strata(fm2),data=model2data,report=c('z','chisquare.test'),
          element.weights=pops)

--- a/massrep.Rmd
+++ b/massrep.Rmd
@@ -126,7 +126,7 @@ balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+m
 ##weighted balance assessment for 2005
 balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+mr01
          +mr02+
-           mr03+mr04+pov05+inc05+emp05+ins05, element.weights=pops, 
+           mr03+mr04+pov05+inc05+emp05+ins05, element.weights=pop06, 
          data=men.study, report=c('all'))
 
 
@@ -150,7 +150,7 @@ balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+m
 ##weighted balance assessment for 2006
 balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+hisp+mr05+mr06+
            mr01+mr02+
-           mr03+mr04+pov06+inc06+emp06+ins06, element.weights=pops, 
+           mr03+mr04+pov06+inc06+emp06+ins06, element.weights=pop06, 
          data=men.study, report=c('all'))
 
 
@@ -178,9 +178,9 @@ men.study.out$mr09d = men.study.out$mr09 - men.study.out$mr06
 men.study.out$mr10d = men.study.out$mr10 - men.study.out$mr06
 
 colnames(men.study.out)
-balanceTest(treat~mr07+mr08+mr09+mr10, element.weights=pops, data=men.study.out,
+balanceTest(treat~mr07+mr08+mr09+mr10, element.weights=pop06, data=men.study.out,
          report=c('z.scores', 'p.value', 'chisquare.test'))
-balanceTest(treat~mr07d+mr08d+mr09d+mr10d, element.weights=pops, data=men.study.out,
+balanceTest(treat~mr07d+mr08d+mr09d+mr10d, element.weights=pop06, data=men.study.out,
          report=c('z.scores', 'p.value', 'chisquare.test'))
 
 ##negative binomial model
@@ -241,7 +241,7 @@ balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+
 balanceTest(treat~a2034+a3544+a4554+a5564+black+otherrace+white+male+
            hisp+mr05+mr06+mr01+mr02+mr03+mr04+pov06+medinc06+unemp06+
            ins06+strata(fm2),data=model2data,report=c('z','chisquare.test'),
-         element.weights=pops)
+         element.weights=pop06)
 
 
 model6 = lm(mr06~a2034+a3544+a4554+black+otherrace+female+hisp+mr01+mr02+mr03

--- a/massrep.Rmd
+++ b/massrep.Rmd
@@ -188,10 +188,9 @@ popa = popall[, c(1:5, 14:16, 22)]
 popa = melt(popa, id=c('state','county','year','racesex','hisp'))
 colnames(popa) = c('state','county','year','racesex','hisp','age','count')
 popa$age = recode(popa$age, "'a3544'=11; 'a4554'=12; 'a5564'=13; 'a2034'=10")
-morta = subset(mort99, mort99$age>=9 & mort99$age <=13)
-morta$age = recode(morta$age, "9=10; 10=10; 11=11; 12=12; 13=13")
-morta = aggregate(deaths~state+county+year+racesex+hisp+age,sum,data=morta)
-deathdata = merge(popa, morta, by=c('state','county','year','racesex','hisp','age'), 
+mortall$age = recode(mortall$age, "9=10; 10=10; 11=11; 12=12; 13=13")
+mortall = aggregate(deaths~state+county+year+racesex+hisp+age,sum,data=mortall)
+deathdata = merge(popa, mortall, by=c('state','county','year','racesex','hisp','age'), 
                   all=T)
 deathdata[is.na(deathdata)]=0
 deathdata$treat=0

--- a/src/repo-setup-notes.md
+++ b/src/repo-setup-notes.md
@@ -55,7 +55,7 @@ library(devtools)
 library(withr)
 LIB <- with(R.version,
             paste0("../lib/", platform, "-library/",
-                  paste0(major, ".", substr(minor, 1,1)),
+                  paste0(major, ".", substr(minor, 1,1))
                   )
             )
 with_libpaths(LIB, install("./RItools"))


### PR DESCRIPTION
In July the RItools clusters branch was merged into its master branch.   This suggestion pulls these changes into the RItools source tree in this repository.   The changes **may** be helpful to you if you're having trouble with `xBalance` calls that involve `element.weights` and/or `strata` arguments.  If those calls to `xBalance` are working fine for you, on the other hand, then feel free to postpone this merge (perhaps indefinitely). To get these changes you can: 
1.  Accept this pull request.  Or, if you want to test this all out first, then just switch over to the bh-suggestions branch (`git checkout bh-suggestions`) before proceeding down this list
2.  Update (ie `git pull`) your local clone of the repo
3.  Run `git submodule update` in your local clone
4.  Re-build your local RItools package from the updated RItools source code (see src/repo-setup-notes.md)

The main change is that a new function `balanceTest` was created, intended to be a replacement function for `xBalance`.  After you've updated everything, you can replace `xBalance` with `balanceTest` throughout.  The updated RItools still has an `xBalance` function, but it's essentially an older version of that function that doesn't accommodate any of the updates that were made to it over the last year or so.  It doesn't accept weights in any fashion, and the procedure for specifying a stratifying variable is fussier.  Example:  

``` r
xBalance(nhTrt ~ nhLogHom+nhAboveHS+nhHS,
                strata=list(nhClass=~nhClass),
                data=meddat, report=c("std.diffs", "adj.means", "chisquare.test"))

```
